### PR TITLE
feat: VM::executeSingle() and VM::isDone()

### DIFF
--- a/VM/include/vm.hpp
+++ b/VM/include/vm.hpp
@@ -103,6 +103,26 @@ class VM {
    * will remain without effect
    */
   void execute();
+
+  /**
+   * execute a single instruction and return;
+   * use this method if you want to control the interpreter
+   * loop yourself (e.g. after executing a instruction you're
+   * able to check if execution was forcefully terminated)
+   * You may construct a loop that can be externally terminated
+   * and also breaks on breakpoints like this:
+   *   bool terminated = false;
+   *   while(!terminated && !vm.executeSingle()) ;
+   * @return true  : a breakpoint (or the end of the prorgram) was reached
+   *         false : no breakpoint was reached
+   */
+  bool executeSingle();
+
+  /**
+   * query if the VM has reached the end of the program
+   * @return true if the end has been reached
+   */
+  bool isDone();
 };
 
 }  // namespace Theo

--- a/VM/src/vm.cpp
+++ b/VM/src/vm.cpp
@@ -80,115 +80,122 @@ void VM::reset() {
   this->data.clear();
   this->stack.clear();
 }
-#include <iostream>
-void VM::execute() {
-  for (;;) {
-    Instruction i = this->code.code[this->instruction_pointer];
-    switch (i.op) {
-      case OpCode::POTENTIAL_BREAK: {
-        // std::cout << "Potential Break" << std::endl;
-        this->instruction_pointer++;
-        if (this->stepping_mode_enabled) {
-          return;
-        }
-        break;
-      }
-      case OpCode::BREAK: {
-        // std::cout << "Break" << std::endl;
-        this->instruction_pointer++;
-        return;
-        break;
-      }
-      case OpCode::HALT: {
-        // std::cout << "Halt" << std::endl;
-        return;
-        break;
-      }
-      case OpCode::ADD_CONST: {
-        // std::cout << "Add Const x" << i.parameters.add.target << " := x" <<
-        // i.parameters.add.source << " + " << i.parameters.add.constant <<
-        // std::endl;
-        WordIndex base = this->stack.back().data_start;
-        this->data[base + i.parameters.add.target] =
-            this->data[base + i.parameters.add.source] +
-            i.parameters.add.constant;
-        this->instruction_pointer++;
-        break;
-      }
-      case OpCode::TEST: {
-        WordIndex base = this->stack.back().data_start;
-        this->data[base + i.parameters.test.target] =
-            (this->data[base + i.parameters.test.op1] ==
-             this->data[base + i.parameters.test.op2])
-                ? 0
-                : 1;
-        this->instruction_pointer++;
-        break;
-      }
-      case OpCode::CONST: {
-        // std::cout << "Const load" << std::endl;
-        WordIndex base = this->stack.back().data_start;
-        this->data[base + i.parameters.constant.target] =
-            i.parameters.constant.constant;
-        this->instruction_pointer++;
-        break;
-      }
-      case OpCode::JMP: {
-        // std::cout << "Jmp" << std::endl;
-        this->instruction_pointer += i.parameters.jmp.offset;
-        break;
-      }
-      case OpCode::JMPC: {
-        // std::cout << "JmpC" << std::endl;
-        WordIndex base = this->stack.back().data_start;
-        if (this->data[base + i.parameters.jmpc.source] == 0)
-          this->instruction_pointer += i.parameters.jmpc.offset;
-        else
-          this->instruction_pointer++;
-        break;
-      }
-      case OpCode::PREPARE_EXEC: {
-        // std::cout << "Prepare Exec" << std::endl;
-        int next_offset = this->data.size();
-        int next_len = i.parameters.prepare.count;
-        RegisterIndex ret_targ = i.parameters.prepare.target;
-        StackMapIndex ind = i.parameters.prepare.index;
-        for (int k = 0; k < next_len; k++) {
-          this->data.push_back(0);
-        }
-        // return address filled by EXEC
-        this->stack.push_back(
-            Activation(this, next_offset, next_len, ret_targ, -1, ind));
-        this->instruction_pointer++;
-        break;
-      }
-      case OpCode::ARG: {
-        // std::cout << "Arg" << std::endl;
-        int source_off = (*(this->stack.end() - 2)).data_start;
-        int target_off = this->stack.back().data_start;
-        this->data[target_off + i.parameters.arg.target] =
-            this->data[source_off + i.parameters.arg.source];
-        this->instruction_pointer++;
-        break;
-      }
-      case OpCode::EXEC: {
-        // std::cout << "Exec" << std::endl;
-        this->stack.back().ret_addr = this->instruction_pointer + 1;
-        this->instruction_pointer = i.parameters.exec.entry;
-        break;
-      }
-      case OpCode::RET: {
-        // std::cout << "Ret" << std::endl;
-        RegisterIndex ret_target = this->stack.back().ret_target;
-        WordIndex target_off = (*(this->stack.end() - 2)).data_start;
-        RegisterIndex ret_source = i.parameters.ret.source;
-        WordIndex source_off = this->stack.back().data_start;
-        this->data[target_off + ret_target] =
-            this->data[source_off + ret_source];
-        this->instruction_pointer = this->stack.back().ret_addr;
-        this->stack.pop_back();
-        break;
-      }
+
+bool VM::isDone() {
+  return this->code.code[this->instruction_pointer].op == OpCode::HALT;
+}
+
+bool VM::executeSingle() {
+  Instruction i = this->code.code[this->instruction_pointer];
+  switch (i.op) {
+  case OpCode::POTENTIAL_BREAK: {
+    // std::cout << "Potential Break" << std::endl;
+    this->instruction_pointer++;
+    if (this->stepping_mode_enabled) {
+      return true;
     }
+    break;
   }
+  case OpCode::BREAK: {
+    // std::cout << "Break" << std::endl;
+    this->instruction_pointer++;
+    return true;
+    break;
+  }
+  case OpCode::HALT: {
+    // std::cout << "Halt" << std::endl;
+    return true;
+    break;
+  }
+  case OpCode::ADD_CONST: {
+    // std::cout << "Add Const x" << i.parameters.add.target << " := x" <<
+    // i.parameters.add.source << " + " << i.parameters.add.constant <<
+    // std::endl;
+    WordIndex base = this->stack.back().data_start;
+    this->data[base + i.parameters.add.target] =
+      this->data[base + i.parameters.add.source] +
+      i.parameters.add.constant;
+    this->instruction_pointer++;
+    break;
+  }
+  case OpCode::TEST: {
+    WordIndex base = this->stack.back().data_start;
+    this->data[base + i.parameters.test.target] =
+      (this->data[base + i.parameters.test.op1] ==
+       this->data[base + i.parameters.test.op2])
+      ? 0
+      : 1;
+    this->instruction_pointer++;
+    break;
+  }
+  case OpCode::CONST: {
+    // std::cout << "Const load" << std::endl;
+    WordIndex base = this->stack.back().data_start;
+    this->data[base + i.parameters.constant.target] =
+      i.parameters.constant.constant;
+    this->instruction_pointer++;
+    break;
+  }
+  case OpCode::JMP: {
+    // std::cout << "Jmp" << std::endl;
+    this->instruction_pointer += i.parameters.jmp.offset;
+    break;
+  }
+  case OpCode::JMPC: {
+    // std::cout << "JmpC" << std::endl;
+    WordIndex base = this->stack.back().data_start;
+    if (this->data[base + i.parameters.jmpc.source] == 0)
+      this->instruction_pointer += i.parameters.jmpc.offset;
+    else
+      this->instruction_pointer++;
+    break;
+  }
+  case OpCode::PREPARE_EXEC: {
+    // std::cout << "Prepare Exec" << std::endl;
+    int next_offset = this->data.size();
+    int next_len = i.parameters.prepare.count;
+    RegisterIndex ret_targ = i.parameters.prepare.target;
+    StackMapIndex ind = i.parameters.prepare.index;
+    for (int k = 0; k < next_len; k++) {
+      this->data.push_back(0);
+    }
+    // return address filled by EXEC
+    this->stack.push_back(
+			  Activation(this, next_offset, next_len, ret_targ, -1, ind));
+    this->instruction_pointer++;
+    break;
+  }
+  case OpCode::ARG: {
+    // std::cout << "Arg" << std::endl;
+    int source_off = (*(this->stack.end() - 2)).data_start;
+    int target_off = this->stack.back().data_start;
+    this->data[target_off + i.parameters.arg.target] =
+      this->data[source_off + i.parameters.arg.source];
+    this->instruction_pointer++;
+    break;
+  }
+  case OpCode::EXEC: {
+    // std::cout << "Exec" << std::endl;
+    this->stack.back().ret_addr = this->instruction_pointer + 1;
+    this->instruction_pointer = i.parameters.exec.entry;
+    break;
+  }
+  case OpCode::RET: {
+    // std::cout << "Ret" << std::endl;
+    RegisterIndex ret_target = this->stack.back().ret_target;
+    WordIndex target_off = (*(this->stack.end() - 2)).data_start;
+    RegisterIndex ret_source = i.parameters.ret.source;
+    WordIndex source_off = this->stack.back().data_start;
+    this->data[target_off + ret_target] =
+      this->data[source_off + ret_source];
+    this->instruction_pointer = this->stack.back().ret_addr;
+    this->stack.pop_back();
+    break;
+  }
+  }
+  return false;
+}
+
+void VM::execute() {
+  while(!executeSingle());
 }


### PR DESCRIPTION
Mit executeSingle lässt sich ein terminierbarer Interpreter bauen:

bool is_terminated = false;

while (!is_terminated && !vm.executeSingle()) ; 