### PR TITLE
fix: no variables < 0

### DIFF
--- a/VM/src/vm.cpp
+++ b/VM/src/vm.cpp
@@ -112,9 +112,9 @@ bool VM::executeSingle() {
     // i.parameters.add.source << " + " << i.parameters.add.constant <<
     // std::endl;
     WordIndex base = this->stack.back().data_start;
-    this->data[base + i.parameters.add.target] =
+    this->data[base + i.parameters.add.target] = std::max(
       this->data[base + i.parameters.add.source] +
-      i.parameters.add.constant;
+      i.parameters.add.constant, 0);
     this->instruction_pointer++;
     break;
   }


### PR DESCRIPTION
In LOOP languages, variables can't be smaller than zero:
x0 := 5 ;
x0 := x0 - 10

-> results in x0 = 0 instead of x0 = -5!